### PR TITLE
rename repository to SimpleMiniFBExample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# SimpleIMGUIExample
+# SimpleMiniFBExample
 
 To run the example, clone the repository and execute the following command inside the cloned directory:
 
 ```
-SimpleIMGUIExample $ julia --project=. -e 'import Pkg; Pkg.instantiate(); include("example.jl")'
+SimpleMiniFBExample $ julia --project=. -e 'import Pkg; Pkg.instantiate(); include("example.jl")'
 ```
 
 Here is how the output looks like:

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ SimpleMiniFBExample $ julia --project=. -e 'import Pkg; Pkg.instantiate(); inclu
 
 Here is how the output looks like:
 
-<img src="https://user-images.githubusercontent.com/32610387/154535306-4e62bca2-0ea0-4484-8874-1e6e81d93c93.png">
+<img src="https://user-images.githubusercontent.com/32610387/159543693-dc4f574e-413a-4bc7-8ad5-098898ee33f8.png">


### PR DESCRIPTION
Rename repository to `SimpleMiniFBExample`

Update screenshot in README:
![simple_imgui_example](https://user-images.githubusercontent.com/32610387/159543693-dc4f574e-413a-4bc7-8ad5-098898ee33f8.png)
